### PR TITLE
Add APDEX score to OpsRamp functionality

### DIFF
--- a/build/kubernetes/helm/opsramp-tracing-proxy/values.yaml
+++ b/build/kubernetes/helm/opsramp-tracing-proxy/values.yaml
@@ -119,6 +119,14 @@ config:
   # "app" label is mandatory
   AddAdditionalMetadata: { "app": "default" }
 
+  # Apdex gives information on performance of a request
+  # Apdex Score = (Satisfied Operations Count + (1/2)(Tolerated Operations Count)) / (Total Spans Count)
+  # Threshold(T) is a ideal duration time of a request in milli seconds
+  # Satisfied Operations Count is Number of spans that has the duration 0 < duration < T
+  # Tolerated Operations Count is Number of spans the has the duration T < duration < 4T
+  # Duration is difference between end and start time of a span
+  Threshold: 500
+
   # EnvironmentCacheTTL is the amount of time a cache entry will live that associates
   # an API key with an environment name.
   # Cache misses lookup the environment name using OpsRampAPI config value.

--- a/build/kubernetes/yaml/k8s-config-cm.yaml
+++ b/build/kubernetes/yaml/k8s-config-cm.yaml
@@ -100,6 +100,14 @@ data:
     # "app" label is mandatory
     AddAdditionalMetadata: { "app": "default" }
     
+    # Apdex gives information on performance of a request
+    # Apdex Score = (Satisfied Operations Count + (1/2)(Tolerated Operations Count)) / (Total Spans Count)
+    # Threshold(T) is a ideal duration time of a request in milli seconds
+    # Satisfied Operations Count is Number of spans that has the duration 0 < duration < T
+    # Tolerated Operations Count is Number of spans the has the duration T < duration < 4T
+    # Duration is difference between end and start time of a span
+    Threshold: 500
+    
     # EnvironmentCacheTTL is the amount of time a cache entry will live that associates
     # an API key with an environment name.
     # Cache misses lookup the environment name using OpsRampAPI config value.

--- a/build/vm/package_directories/opt/opsramp/tracing-proxy/conf/config_complete.yaml
+++ b/build/vm/package_directories/opt/opsramp/tracing-proxy/conf/config_complete.yaml
@@ -86,6 +86,14 @@ AddHostMetadataToTrace: false
 # "app" label is mandatory
 AddAdditionalMetadata: { "app": "default" }
 
+# Apdex gives information on performance of a request
+# Apdex Score = (Satisfied Operations Count + (1/2)(Tolerated Operations Count)) / (Total Spans Count)
+# Threshold(T) is a ideal duration time of a request in milli seconds
+# Satisfied Operations Count is Number of spans that has the duration 0 < duration < T
+# Tolerated Operations Count is Number of spans the has the duration T < duration < 4T
+# Duration is difference between end and start time of a span
+Threshold: 500
+
 # EnvironmentCacheTTL is the amount of time a cache entry will live that associates
 # an API key with an environment name.
 # Cache misses lookup the environment name using OpsRampAPI config value.

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -37,7 +37,7 @@ func GetCollectorImplementation(c config.Config) Collector {
 
 	// Get aThreshold value and set it to default by 100 and re-assign it with quarter value for bucket
 	Threshold = c.GetThreshold()
-	if Threshold < 1 {
+	if Threshold < 0 {
 		Threshold = 100
 	} else {
 		Threshold = Threshold / 4
@@ -103,11 +103,11 @@ func (i *InMemCollector) Start() error {
 	i.cache = cache.NewInMemCache(imcConfig.CacheCapacity, i.Metrics, i.Logger)
 
 	// threshold bucket ranges
-	var thresholdBuckets = []float64{0, Threshold}
+	var thresholdBuckets = []float64{Threshold}
 	for i := 2; i <= 16; i++ {
 		thresholdBuckets = append(thresholdBuckets, Threshold*float64(i))
 	}
-	thresholdBuckets = append(thresholdBuckets, 64*Threshold)
+	thresholdBuckets = append(thresholdBuckets, 32*Threshold, 64*Threshold)
 
 	// listen for config reloads
 	i.Config.RegisterReloadCallback(i.sendReloadSignal)

--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,9 @@ type Config interface {
 	// GetMaxBatchSize is the number of events to be included in the batch for sending
 	GetMaxBatchSize() uint
 
+	// GetThreshold is used to caliculate the apdex score
+	GetThreshold() float64
+
 	// GetOtherConfig attempts to fill the passed in struct with the contents of
 	// a subsection of the config.   This is used by optional configurations to
 	// allow different implementations of necessary interfaces configure

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -63,6 +63,7 @@ type configContents struct {
 	InMemCollector            InMemoryCollectorCacheCapacity `validate:"required"`
 	AddHostMetadataToTrace    bool
 	AddAdditionalMetadata     map[string]string
+	Threshold                 float64 `validate:"required"`
 	AddRuleReasonToTrace      bool
 	EnvironmentCacheTTL       time.Duration
 	DatasetPrefix             string
@@ -468,6 +469,13 @@ func (f *fileConfig) GetCompressPeerCommunication() bool {
 	defer f.mux.RUnlock()
 
 	return f.conf.CompressPeerCommunication
+}
+
+func (f *fileConfig) GetThreshold() float64 {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.conf.Threshold
 }
 
 func (f *fileConfig) GetGRPCListenAddr() (string, error) {

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -86,6 +86,15 @@ AddHostMetadataToTrace: false
 # "app" label is mandatory
 AddAdditionalMetadata: { "app": "default" }
 
+# Apdex gives information on performance of a request
+# Apdex Score = (Satisfied Operations Count + (1/2)(Tolerated Operations Count)) / (Total Spans Count)
+# Threshold(T) is a ideal duration time of a request in milli seconds
+# Satisfied Operations Count is Number of spans that has the duration 0 < duration < T
+# Tolerated Operations Count is Number of spans the has the duration T < duration < 4T
+# Duration is difference between end and start time of a span
+Threshold: 500
+
+
 # EnvironmentCacheTTL is the amount of time a cache entry will live that associates
 # an API key with an environment name.
 # Cache misses lookup the environment name using OpsRampAPI config value.


### PR DESCRIPTION
User can give the apdex threshold in config section of tracing-proxy. Threshold assigned to 400 if user gave lessthan 0.

The query can use in dashboards is

 
(sum(trace_apdex_latency_bucket{le="500"}) by (app, service_name, operation)+((1/2)*(sum(trace_apdex_latency_bucket{le="2000"}) by (app, service_name, operation) - sum(trace_apdex_latency_bucket{le="500"}) by (app, service_name, operation)))) /
sum(trace_apdex_latency_count) by (app, service_name, operation)
 
le is the value a user can give as threshold.

Possible values of le can user give based on threshold given collector side is,
 
Lets say user gave 500 in collector side the possible values are:
[ 125,250,375,500,625,750,875,1000,1125,1250,1375,1500,1625,1750,1875,2000,4000,8000 ] that is [ Thereshold / 4 to 4 * Threshold and 8 * Threshold and 16 * Threshold ].